### PR TITLE
Add Cloudflare Worker proxy to fix GitHub Actions IP blocks on scraper

### DIFF
--- a/.github/workflows/daily-scraper.yml
+++ b/.github/workflows/daily-scraper.yml
@@ -89,6 +89,9 @@ jobs:
       # ── Normal scraper run (skipped if all sources down) ──
       - name: Run Naukri Dhaba scraper
         if: steps.source_check.outputs.sources_down != 'true'
+        env:
+          CF_WORKER_PROXY_URL: ${{ secrets.CF_WORKER_PROXY_URL }}
+          CF_WORKER_SECRET: ${{ secrets.CF_WORKER_SECRET }}
         run: |
           echo "=== Naukri Dhaba Scraper ==="
           echo "Time (IST): $(date)"

--- a/scraper/cf-proxy-worker.js
+++ b/scraper/cf-proxy-worker.js
@@ -1,0 +1,89 @@
+/**
+ * Naukri Dhaba — Cloudflare Fetch Proxy Worker
+ *
+ * Deploys on Cloudflare Workers (free tier: 100,000 req/day).
+ * Acts as a fetch relay so GitHub Actions can scrape sites
+ * that block GitHub's IP ranges.
+ *
+ * HOW TO DEPLOY:
+ *   1. Go to https://dash.cloudflare.com → Workers & Pages → Create
+ *   2. Paste this entire file → Deploy
+ *   3. Copy the Worker URL (e.g. https://nd-proxy.YOUR-NAME.workers.dev)
+ *   4. Add to GitHub repo secrets:
+ *        CF_WORKER_PROXY_URL = https://nd-proxy.YOUR-NAME.workers.dev
+ *        CF_WORKER_SECRET    = (any random string, same as PROXY_SECRET below)
+ *   5. Also add the same secret as a Worker env var in the Cloudflare dashboard:
+ *        Settings → Variables → PROXY_SECRET = <your random string>
+ *
+ * USAGE (called by scraper automatically):
+ *   GET https://nd-proxy.YOUR-NAME.workers.dev/?url=https://www.sarkariresult.com/latestjob.php
+ *   Header: X-Proxy-Secret: <your secret>
+ */
+
+const ALLOWED_HOSTS = [
+  'sarkariresult.com',
+  'www.sarkariresult.com',
+  'freejobalert.com',
+  'www.freejobalert.com',
+  'rojgarresult.com',
+  'www.rojgarresult.com',
+];
+
+export default {
+  async fetch(request, env) {
+    // ── Secret check ──────────────────────────────────────
+    const secret = env.PROXY_SECRET;
+    if (secret) {
+      const provided = request.headers.get('X-Proxy-Secret') || '';
+      if (provided !== secret) {
+        return new Response('Forbidden', { status: 403 });
+      }
+    }
+
+    // ── Parse target URL ──────────────────────────────────
+    const { searchParams } = new URL(request.url);
+    const targetUrl = searchParams.get('url');
+    if (!targetUrl) {
+      return new Response('Missing ?url= parameter', { status: 400 });
+    }
+
+    // ── Validate host is in allowed list ──────────────────
+    let targetHost;
+    try {
+      targetHost = new URL(targetUrl).hostname;
+    } catch {
+      return new Response('Invalid URL', { status: 400 });
+    }
+    if (!ALLOWED_HOSTS.includes(targetHost)) {
+      return new Response(`Host not allowed: ${targetHost}`, { status: 403 });
+    }
+
+    // ── Fetch from Cloudflare edge ────────────────────────
+    try {
+      const response = await fetch(targetUrl, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.9,hi;q=0.8',
+          'Accept-Encoding': 'gzip, deflate, br',
+          'Cache-Control': 'no-cache',
+          'Referer': `https://${targetHost}/`,
+        },
+        redirect: 'follow',
+        cf: { cacheTtl: 0, cacheEverything: false },
+      });
+
+      const body = await response.arrayBuffer();
+      return new Response(body, {
+        status: response.status,
+        headers: {
+          'Content-Type': response.headers.get('Content-Type') || 'text/html; charset=utf-8',
+          'X-Proxied-By': 'cf-worker',
+          'X-Origin-Status': String(response.status),
+        },
+      });
+    } catch (err) {
+      return new Response(`Fetch error: ${err.message}`, { status: 502 });
+    }
+  },
+};

--- a/scraper/check_sources.py
+++ b/scraper/check_sources.py
@@ -40,8 +40,28 @@ HEADERS = {
 }
 
 
+CF_WORKER_URL    = os.environ.get("CF_WORKER_PROXY_URL", "").rstrip("/")
+CF_WORKER_SECRET = os.environ.get("CF_WORKER_SECRET", "")
+
+
 def check_url(url: str) -> tuple[bool, str]:
-    """Return (reachable, reason)."""
+    """Return (reachable, reason). Uses CF Worker proxy if configured."""
+    # Try via Cloudflare Worker first
+    if CF_WORKER_URL:
+        try:
+            from urllib.parse import quote
+            proxy_url = f"{CF_WORKER_URL}/?url={quote(url, safe='')}"
+            proxy_headers = dict(HEADERS)
+            if CF_WORKER_SECRET:
+                proxy_headers["X-Proxy-Secret"] = CF_WORKER_SECRET
+            req = Request(proxy_url, headers=proxy_headers, method="GET")
+            with urlopen(req, timeout=TIMEOUT) as resp:
+                if resp.status < 400:
+                    return True, f"HTTP {resp.status} (via CF Worker)"
+        except Exception:
+            pass  # fall through to direct check
+
+    # Direct fetch fallback
     try:
         req = Request(url, headers=HEADERS, method="GET")
         with urlopen(req, timeout=TIMEOUT) as resp:

--- a/scraper/sarkari_scraper.py
+++ b/scraper/sarkari_scraper.py
@@ -595,7 +595,34 @@ if cloudscraper is not None:
         log.warning(f'Cloudscraper init failed, falling back to requests: {exc}')
         _cf_session = None
 
+# Cloudflare Worker proxy (set CF_WORKER_PROXY_URL env var to enable)
+_CF_WORKER_URL    = os.environ.get('CF_WORKER_PROXY_URL', '').rstrip('/')
+_CF_WORKER_SECRET = os.environ.get('CF_WORKER_SECRET', '')
+
+def _fetch_via_worker(url: str) -> BeautifulSoup | None:
+    """Fetch a URL through the Cloudflare Worker proxy."""
+    proxy_url = f'{_CF_WORKER_URL}/?url={requests.utils.quote(url, safe="")}'
+    headers = {}
+    if _CF_WORKER_SECRET:
+        headers['X-Proxy-Secret'] = _CF_WORKER_SECRET
+    try:
+        r = _session.get(proxy_url, headers=headers, timeout=TIMEOUT)
+        r.raise_for_status()
+        return BeautifulSoup(r.content, 'lxml')
+    except Exception as exc:
+        log.warning(f'CF Worker fetch failed for {url}: {exc}')
+        return None
+
 def fetch(url: str, retries: int = 3) -> BeautifulSoup | None:
+    # Try Cloudflare Worker first if configured
+    if _CF_WORKER_URL:
+        log.info(f'GET {url} via CF Worker')
+        result = _fetch_via_worker(url)
+        if result is not None:
+            time.sleep(DELAY)
+            return result
+        log.warning(f'CF Worker failed for {url}, falling back to direct fetch')
+
     sessions = [_session]
     if _cf_session is not None:
         sessions.insert(0, _cf_session)


### PR DESCRIPTION
- cf-proxy-worker.js: new Worker that fetches target sites from Cloudflare edge IPs (free tier, 100k req/day), protected by secret key
- sarkari_scraper.py: route fetch() through CF Worker when CF_WORKER_PROXY_URL env var is set, falls back to direct if Worker fails
- check_sources.py: same CF Worker routing for pre-flight source check
- daily-scraper.yml: pass CF_WORKER_PROXY_URL and CF_WORKER_SECRET secrets to scraper step

https://claude.ai/code/session_012ugADf1A22dp4KTDo2c3vz