### PR TITLE
fix: use merge instead of rebase for scraper commit step

### DIFF
--- a/.github/workflows/daily-scraper.yml
+++ b/.github/workflows/daily-scraper.yml
@@ -99,8 +99,11 @@ jobs:
             COUNT=$(git diff --staged --name-only | wc -l)
             git commit -m "Auto-scrape $(date +'%d %b %Y %I:%M %p IST') - $COUNT files"
             # Retry push up to 4 times with exponential backoff
+            # Use merge (not rebase) to avoid conflicts on auto-generated files
             for attempt in 1 2 3 4; do
-              git pull --rebase origin main && git push && break
+              # Abort any stuck rebase from a previous attempt
+              git rebase --abort 2>/dev/null || true
+              git pull --no-rebase origin main -X theirs && git push && break
               echo "Push attempt $attempt failed, retrying in $((attempt * 2))s..."
               sleep $((attempt * 2))
             done


### PR DESCRIPTION
Rebase fails when auto-generated files (feeds, listings, API JSON) conflict with upstream changes. Switch to `git pull --no-rebase -X theirs` which auto-resolves conflicts by preferring the freshly scraped content.

https://claude.ai/code/session_01LrjJFMG7JTEhLGTkiqgjRn