### PR TITLE
fix: AdSense script as static HTML tag so crawler can verify

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -86,9 +86,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           strategy="afterInteractive"
           src={`https://www.googletagmanager.com/gtm.js?id=${GTM_ID}`}
         />
-        <Script
-          id="adsense"
-          strategy="afterInteractive"
+        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+        <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5296074722684627"
           crossOrigin="anonymous"


### PR DESCRIPTION
Next.js `Script` with `afterInteractive` injects the tag via JS after hydration — not in the raw HTML. AdSense crawler does a static HTTP fetch and never sees it, so verification fails.

This changes it to a plain `<script async>` directly in `<head>` so it's in the static HTML source on every page.

https://claude.ai/code/session_019qytP4JkZ9JRBKw5Rf4xcZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019qytP4JkZ9JRBKw5Rf4xcZ)_